### PR TITLE
코드 리팩토링, 기능 추가 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,8 @@ const App = () => {
       <div className="contents">
         <Routes>
           <Route path="/" element={<Navigate replace to="/todo" />} />
-          {/*
-          <Route path="/signin" element={<SigninTemplate />} />
-          <Route path="/signup" element={<SignupTemplate />} />
-          */}
 
-          <Route path="/signin" element={<AuthTemplate path="signin" />} />
-          <Route path="/signup" element={<AuthTemplate path="signup" />} />
-
+          <Route path="/auth/*" element={<AuthTemplate />} />
           <Route path="/todo" element={<TodoTemplate />} />
         </Routes>
       </div>

--- a/src/api/todo/todoApi.ts
+++ b/src/api/todo/todoApi.ts
@@ -75,6 +75,6 @@ export interface TodoData {
   title: string;
   content: string;
   id: string;
-  createAt: string;
+  createdAt: string;
   updatedAt: string;
 }

--- a/src/components/auth/Signin.tsx
+++ b/src/components/auth/Signin.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import * as layoutActions from '../../modules/layout/actions';
 import * as authActions from '../../modules/auth/actions';
 import { RootState } from '../../modules';
 import axios from 'axios';
+import { PAGE } from '../../enums/commonEnum';
 import { REGEX_EMAIL, REGEX_PASSWORD } from '../../enums/regex';
 
 type InputType = {
@@ -17,6 +19,10 @@ const Signin = () => {
 
   const [input, setInput] = useState<InputType>({ email: '', password: '', isValid: null });
   const [isValidButton, setIsValidButton] = useState<boolean>(false);
+
+  useEffect(() => {
+    dispatch(layoutActions.setPage(PAGE.SIGN_IN));
+  }, []);
 
   useEffect(() => {
     if (data && data.message) {

--- a/src/components/auth/Signup.tsx
+++ b/src/components/auth/Signup.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import * as layoutActions from '../../modules/layout/actions';
 import * as authActions from '../../modules/auth/actions';
 import { RootState } from '../../modules';
 import axios from 'axios';
+import { PAGE } from '../../enums/commonEnum';
 import { REGEX_EMAIL, REGEX_PASSWORD } from '../../enums/regex';
 
 type InputType = {
@@ -18,6 +20,10 @@ const Signup = () => {
   const [inputPassword, setInputPassword] = useState<InputType>({ value: '', isValid: null });
   const [inputPasswordCheck, setInputPasswordCheck] = useState<{ isValid: boolean | null }>({ isValid: null });
   const [isValidButton, setIsValidButton] = useState<boolean>(false);
+
+  useEffect(() => {
+    dispatch(layoutActions.setPage(PAGE.SIGN_IN));
+  }, []);
 
   useEffect(() => {
     if (data && data.message) {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { RootState } from '../../modules';
 
-const Header = ({ title }: { title: string }) => {
+const Header = () => {
+  const { header } = useSelector((state: RootState) => state.layout);
+
   return (
     <HeaderWrapper>
-      <h1>{title}</h1>
+      <h1>{header.title}</h1>
     </HeaderWrapper>
   );
 };

--- a/src/enums/commonEnum.ts
+++ b/src/enums/commonEnum.ts
@@ -1,0 +1,5 @@
+export enum PAGE {
+  SIGN_IN = 'SIGN_IN',
+  SIGN_UP = 'SIGN_UP',
+  TODO_LIST = 'TODO_LIST',
+}

--- a/src/modules/auth/actions.ts
+++ b/src/modules/auth/actions.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
-import { createAsyncAction } from 'typesafe-actions';
+import { createAction, createAsyncAction } from 'typesafe-actions';
 import { AuthResponse, AuthParam } from '../../api/auth/authApi';
-import { SIGNIN, SIGNIN_ERROR, SIGNIN_SUCCESS, SIGNUP, SIGNUP_ERROR, SIGNUP_SUCCESS } from './types';
+import { SIGNIN, SIGNIN_ERROR, SIGNIN_SUCCESS, SIGNUP, SIGNUP_ERROR, SIGNUP_SUCCESS, SET_AUTH_TOKEN } from './types';
 
 // action
 
@@ -10,8 +10,11 @@ export const signinAsync = createAsyncAction(SIGNIN, SIGNIN_SUCCESS, SIGNIN_ERRO
   AuthResponse,
   AxiosError
 >();
+
 export const signupAsync = createAsyncAction(SIGNUP, SIGNUP_SUCCESS, SIGNUP_ERROR)<
   AuthParam,
   AuthResponse,
   AxiosError
 >();
+
+export const setAuthToken = createAction(SET_AUTH_TOKEN)<string>();

--- a/src/modules/auth/reducer.ts
+++ b/src/modules/auth/reducer.ts
@@ -1,7 +1,7 @@
 import { ActionType, createReducer } from 'typesafe-actions';
 import { AuthResponse } from '../../api/auth/authApi';
 import { Response } from '../index';
-import { SIGNIN, SIGNIN_SUCCESS, SIGNIN_ERROR, SIGNUP, SIGNUP_SUCCESS, SIGNUP_ERROR } from './types';
+import { SIGNIN, SIGNIN_SUCCESS, SIGNIN_ERROR, SIGNUP, SIGNUP_SUCCESS, SIGNUP_ERROR, SET_AUTH_TOKEN } from './types';
 import * as actions from './actions';
 
 // reducer
@@ -35,6 +35,11 @@ const auth = createReducer<AuthState, AuthAction>(initialState, {
   [SIGNUP_ERROR]: (state, { payload }) => ({
     ...state,
     user: { data: null, loading: false, error: payload },
+  }),
+
+  [SET_AUTH_TOKEN]: (state, { payload }) => ({
+    ...state,
+    user: { ...state.user, data: { message: '', token: payload } },
   }),
 });
 

--- a/src/modules/auth/types.ts
+++ b/src/modules/auth/types.ts
@@ -1,9 +1,11 @@
 // type
 
-export const SIGNIN = 'SIGNIN';
-export const SIGNIN_SUCCESS = 'SIGNIN_SUCCESS';
-export const SIGNIN_ERROR = 'SIGNIN_ERROR';
+export const SIGNIN = 'auth/SIGNIN';
+export const SIGNIN_SUCCESS = 'auth/SIGNIN_SUCCESS';
+export const SIGNIN_ERROR = 'auth/SIGNIN_ERROR';
 
-export const SIGNUP = 'SIGNUP';
-export const SIGNUP_SUCCESS = 'SIGNUP_SUCCESS';
-export const SIGNUP_ERROR = 'SIGNUP_ERROR';
+export const SIGNUP = 'auth/SIGNUP';
+export const SIGNUP_SUCCESS = 'auth/SIGNUP_SUCCESS';
+export const SIGNUP_ERROR = 'auth/SIGNUP_ERROR';
+
+export const SET_AUTH_TOKEN = 'auth/SET_AUTH_TOKEN';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,13 +1,15 @@
 import { combineReducers } from 'redux';
 import { all } from 'redux-saga/effects';
-import todo from './todo';
+import layout from './layout';
 import auth from './auth';
-import { todoSaga } from './todo';
+import todo from './todo';
 import { authSaga } from './auth';
+import { todoSaga } from './todo';
 import { AxiosError } from 'axios';
 import { ErrorResponse } from '../api/Api';
 
 const rootReducer = combineReducers({
+  layout,
   auth,
   todo,
 });

--- a/src/modules/layout/actions.ts
+++ b/src/modules/layout/actions.ts
@@ -1,0 +1,7 @@
+import { createAction } from 'typesafe-actions';
+import { PAGE } from '../../enums/commonEnum';
+import { SET_HEADER_TITLE, SET_PAGE } from './types';
+
+export const setPage = createAction(SET_PAGE)<PAGE>();
+
+export const setHeaderTitle = createAction(SET_HEADER_TITLE)<string>();

--- a/src/modules/layout/index.ts
+++ b/src/modules/layout/index.ts
@@ -1,0 +1,3 @@
+export { default } from './reducer';
+export * from './actions';
+export * from './types';

--- a/src/modules/layout/reducer.ts
+++ b/src/modules/layout/reducer.ts
@@ -1,0 +1,27 @@
+import { ActionType, createReducer } from 'typesafe-actions';
+import { PAGE } from '../../enums/commonEnum';
+import * as actions from './actions';
+import { SET_PAGE, SET_HEADER_TITLE } from './types';
+
+const initialState: LayoutState = {
+  page: null,
+  header: {
+    title: null,
+  },
+};
+
+type LayoutAction = ActionType<typeof actions>;
+
+type LayoutState = {
+  page: PAGE | null;
+  header: {
+    title: string | null;
+  };
+};
+
+const layout = createReducer<LayoutState, LayoutAction>(initialState, {
+  [SET_PAGE]: (state, { payload }) => ({ ...state, page: payload }),
+  [SET_HEADER_TITLE]: (state, { payload }) => ({ ...state, header: { title: payload } }),
+});
+
+export default layout;

--- a/src/modules/layout/types.ts
+++ b/src/modules/layout/types.ts
@@ -1,0 +1,2 @@
+export const SET_PAGE = 'layout/SET_PAGE';
+export const SET_HEADER_TITLE = 'layout/SET_HEADER_TITLE';

--- a/src/modules/todo/actions.ts
+++ b/src/modules/todo/actions.ts
@@ -47,6 +47,6 @@ export const updateTodoAsync = createAsyncAction(UPDATE_TODO, UPDATE_TODO_SUCCES
 
 export const deleteTodoAsync = createAsyncAction(DELETE_TODO, DELETE_TODO_SUCCESS, DELETE_TODO_ERROR)<
   { id: Id; authToken: AuthToken },
-  { data: null | string },
+  null | string,
   AxiosError
 >();

--- a/src/modules/todo/reducer.ts
+++ b/src/modules/todo/reducer.ts
@@ -1,7 +1,23 @@
 import { ActionType, createReducer } from 'typesafe-actions';
 import { TodoData } from '../../api/todo/todoApi';
 import { Response } from '../index';
-import { GET_TODOS, GET_TODOS_SUCCESS, GET_TODOS_ERROR } from './types';
+import {
+  GET_TODOS,
+  GET_TODOS_SUCCESS,
+  GET_TODOS_ERROR,
+  GET_TODO_BY_ID,
+  GET_TODO_BY_ID_SUCCESS,
+  GET_TODO_BY_ID_ERROR,
+  CREATE_TODO,
+  CREATE_TODO_SUCCESS,
+  CREATE_TODO_ERROR,
+  UPDATE_TODO,
+  UPDATE_TODO_SUCCESS,
+  UPDATE_TODO_ERROR,
+  DELETE_TODO,
+  DELETE_TODO_SUCCESS,
+  DELETE_TODO_ERROR,
+} from './types';
 import * as actions from './actions';
 
 // reducer
@@ -32,7 +48,22 @@ const todo = createReducer<TodoState, TodoAction>(initialState, {
       todoList: { data: payload, loading: false, error: null },
     };
   },
-  [GET_TODOS_ERROR]: (state, { payload }) => ({ ...state, todoList: { data: null, loading: false, error: payload } }),
+  [GET_TODOS_ERROR]: (state, { payload }) => ({
+    ...state,
+    todoList: { data: null, loading: false, error: payload },
+  }),
+
+  [GET_TODO_BY_ID]: state => ({ ...state, todoDetail: { data: null, loading: true, error: null } }),
+  [GET_TODO_BY_ID_SUCCESS]: (state, { payload }) => {
+    return {
+      ...state,
+      todoDetail: { data: payload, loading: false, error: null },
+    };
+  },
+  [GET_TODO_BY_ID_ERROR]: (state, { payload }) => ({
+    ...state,
+    todoDetail: { data: null, loading: false, error: payload },
+  }),
 });
 
 export default todo;

--- a/src/modules/todo/sagas.ts
+++ b/src/modules/todo/sagas.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { call, put, takeEvery } from 'redux-saga/effects';
 import todoAPI, { TodoData, TodoResponse } from '../../api/todo/todoApi';
-import { getTodoByIdAsync, getTodosAsync } from './actions';
+import { getTodosAsync, getTodoByIdAsync, createTodoAsync, updateTodoAsync, deleteTodoAsync } from './actions';
 import { GET_TODOS, GET_TODO_BY_ID, CREATE_TODO, UPDATE_TODO, DELETE_TODO } from './types';
 
 //saga
@@ -30,7 +30,46 @@ function* getTodoByIdSaga({ payload }: ReturnType<typeof getTodoByIdAsync.reques
   }
 }
 
+function* createTodoSaga({ payload }: ReturnType<typeof createTodoAsync.request>) {
+  try {
+    const response: TodoResponse<TodoData> = yield call(todoAPI.create, payload);
+    if (!response.data) throw new Error('There is no response result data.');
+    yield put(createTodoAsync.success(response.data));
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      yield put(createTodoAsync.failure(e));
+    }
+  }
+}
+
+function* updateTodoSaga({ payload }: ReturnType<typeof updateTodoAsync.request>) {
+  try {
+    const response: TodoResponse<TodoData> = yield call(todoAPI.update, payload);
+    if (!response.data) throw new Error('There is no response result data.');
+    yield put(updateTodoAsync.success(response.data));
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      yield put(updateTodoAsync.failure(e));
+    }
+  }
+}
+
+function* deleteTodoSaga({ payload }: ReturnType<typeof deleteTodoAsync.request>) {
+  try {
+    const response: TodoResponse<string> = yield call(todoAPI.delete, payload);
+    if (!response.data) throw new Error('There is no response result data.');
+    yield put(deleteTodoAsync.success(response.data));
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      yield put(deleteTodoAsync.failure(e));
+    }
+  }
+}
+
 export function* todoSaga() {
   yield takeEvery(GET_TODOS, getTodosSaga);
   yield takeEvery(GET_TODO_BY_ID, getTodoByIdSaga);
+  yield takeEvery(CREATE_TODO, createTodoSaga);
+  yield takeEvery(UPDATE_TODO, updateTodoSaga);
+  yield takeEvery(DELETE_TODO, deleteTodoSaga);
 }

--- a/src/modules/todo/sagas.ts
+++ b/src/modules/todo/sagas.ts
@@ -1,31 +1,15 @@
 import axios from 'axios';
 import { call, put, takeEvery } from 'redux-saga/effects';
 import todoAPI, { TodoData, TodoResponse } from '../../api/todo/todoApi';
-import { getTodosAsync } from './actions';
-import {
-  GET_TODOS,
-  GET_TODOS_SUCCESS,
-  GET_TODOS_ERROR,
-  GET_TODO_BY_ID,
-  GET_TODO_BY_ID_SUCCESS,
-  GET_TODO_BY_ID_ERROR,
-  CREATE_TODO,
-  CREATE_TODO_SUCCESS,
-  CREATE_TODO_ERROR,
-  UPDATE_TODO,
-  UPDATE_TODO_SUCCESS,
-  UPDATE_TODO_ERROR,
-  DELETE_TODO,
-  DELETE_TODO_SUCCESS,
-  DELETE_TODO_ERROR,
-} from './types';
+import { getTodoByIdAsync, getTodosAsync } from './actions';
+import { GET_TODOS, GET_TODO_BY_ID, CREATE_TODO, UPDATE_TODO, DELETE_TODO } from './types';
 
 //saga
 
 function* getTodosSaga({ payload }: ReturnType<typeof getTodosAsync.request>) {
   try {
     const response: TodoResponse<TodoData[]> = yield call(todoAPI.getAll, payload);
-    if (!response.data) throw new Error();
+    if (!response.data) throw new Error('There is no response result data.');
     yield put(getTodosAsync.success(response.data));
   } catch (e) {
     if (axios.isAxiosError(e)) {
@@ -34,6 +18,19 @@ function* getTodosSaga({ payload }: ReturnType<typeof getTodosAsync.request>) {
   }
 }
 
+function* getTodoByIdSaga({ payload }: ReturnType<typeof getTodoByIdAsync.request>) {
+  try {
+    const response: TodoResponse<TodoData> = yield call(todoAPI.getById, payload);
+    if (!response.data) throw new Error('There is no response result data.');
+    yield put(getTodoByIdAsync.success(response.data));
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      yield put(getTodoByIdAsync.failure(e));
+    }
+  }
+}
+
 export function* todoSaga() {
   yield takeEvery(GET_TODOS, getTodosSaga);
+  yield takeEvery(GET_TODO_BY_ID, getTodoByIdSaga);
 }

--- a/src/modules/todo/types.ts
+++ b/src/modules/todo/types.ts
@@ -1,21 +1,21 @@
 // type
 
-export const GET_TODOS = 'GET_TODOS';
-export const GET_TODOS_SUCCESS = 'GET_TODOS_SUCCESS';
-export const GET_TODOS_ERROR = 'GET_TODOS_ERROR';
+export const GET_TODOS = 'todo/GET_TODOS';
+export const GET_TODOS_SUCCESS = 'todo/GET_TODOS_SUCCESS';
+export const GET_TODOS_ERROR = 'todo/GET_TODOS_ERROR';
 
-export const GET_TODO_BY_ID = 'GET_TODO_BY_ID';
-export const GET_TODO_BY_ID_SUCCESS = 'GET_TODO_BY_ID_SUCCESS';
-export const GET_TODO_BY_ID_ERROR = 'GET_TODO_BY_ID_ERROR';
+export const GET_TODO_BY_ID = 'todo/GET_TODO_BY_ID';
+export const GET_TODO_BY_ID_SUCCESS = 'todo/GET_TODO_BY_ID_SUCCESS';
+export const GET_TODO_BY_ID_ERROR = 'todo/GET_TODO_BY_ID_ERROR';
 
-export const CREATE_TODO = 'CREATE_TODO';
-export const CREATE_TODO_SUCCESS = 'CREATE_TODO_SUCCESS';
-export const CREATE_TODO_ERROR = 'CREATE_TODO_ERROR';
+export const CREATE_TODO = 'todo/CREATE_TODO';
+export const CREATE_TODO_SUCCESS = 'todo/CREATE_TODO_SUCCESS';
+export const CREATE_TODO_ERROR = 'todo/CREATE_TODO_ERROR';
 
-export const UPDATE_TODO = 'UPDATE_TODO';
-export const UPDATE_TODO_SUCCESS = 'UPDATE_TODO_SUCCESS';
-export const UPDATE_TODO_ERROR = 'UPDATE_TODO_ERROR';
+export const UPDATE_TODO = 'todo/UPDATE_TODO';
+export const UPDATE_TODO_SUCCESS = 'todo/UPDATE_TODO_SUCCESS';
+export const UPDATE_TODO_ERROR = 'todo/UPDATE_TODO_ERROR';
 
-export const DELETE_TODO = 'DELETE_TODO';
-export const DELETE_TODO_SUCCESS = 'DELETE_TODO_SUCCESS';
-export const DELETE_TODO_ERROR = 'DELETE_TODO_ERROR';
+export const DELETE_TODO = 'todo/DELETE_TODO';
+export const DELETE_TODO_SUCCESS = 'todo/DELETE_TODO_SUCCESS';
+export const DELETE_TODO_ERROR = 'todo/DELETE_TODO_ERROR';

--- a/src/page/ AuthTemplate.tsx
+++ b/src/page/ AuthTemplate.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import * as layoutActions from '../modules/layout/actions';
 import Header from '../components/common/Header';
 import Signin from '../components/auth/Signin';
 import Signup from '../components/auth/Signup';
@@ -8,6 +9,12 @@ import styled from 'styled-components';
 
 const AuthTemplate = () => {
   const authToken = window.localStorage.getItem('authToken');
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(layoutActions.setHeaderTitle('Authentication'));
+  }, []);
 
   useEffect(() => {
     console.log(authToken);
@@ -19,7 +26,7 @@ const AuthTemplate = () => {
 
   return (
     <AuthContainer>
-      <Header title="Authentication" />
+      <Header />
       <Routes>
         <Route path="signin" element={<Signin />} />
         <Route path="signup" element={<Signup />} />

--- a/src/page/ AuthTemplate.tsx
+++ b/src/page/ AuthTemplate.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import Header from '../components/common/Header';
 import Signin from '../components/auth/Signin';
 import Signup from '../components/auth/Signup';
 import styled from 'styled-components';
 
-const AuthTemplate = ({ path }: { path: string }) => {
+const AuthTemplate = () => {
   const authToken = window.localStorage.getItem('authToken');
 
   useEffect(() => {
@@ -18,8 +20,10 @@ const AuthTemplate = ({ path }: { path: string }) => {
   return (
     <AuthContainer>
       <Header title="Authentication" />
-      {path == 'signin' && <Signin />}
-      {path == 'signup' && <Signup />}
+      <Routes>
+        <Route path="signin" element={<Signin />} />
+        <Route path="signup" element={<Signup />} />
+      </Routes>
     </AuthContainer>
   );
 };

--- a/src/page/TodoTemplate.tsx
+++ b/src/page/TodoTemplate.tsx
@@ -1,15 +1,22 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import * as layoutActions from '../modules/layout/actions';
 import * as todoActions from '../modules/todo/actions';
 import Header from '../components/common/Header';
 import TodoCreate from '../components/todo/TodoCreate';
 import TodoList from '../components/todo/TodoList';
 import styled from 'styled-components';
 import FloatingButton from '../components/common/FloatingButton';
+import { PAGE } from '../enums/commonEnum';
 
 const TodoTemplate = () => {
   const authToken = window.localStorage.getItem('authToken');
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(layoutActions.setPage(PAGE.TODO_LIST));
+    dispatch(layoutActions.setHeaderTitle('TO DO LIST'));
+  }, []);
 
   useEffect(() => {
     console.log(authToken);
@@ -23,7 +30,7 @@ const TodoTemplate = () => {
   return (
     <>
       <TodoContainer>
-        <Header title="TO DO LIST" />
+        <Header />
         <TodoList />
         <TodoCreate />
       </TodoContainer>


### PR DESCRIPTION
# 코드 리팩토링

### props로 잘못 처리하던 부분 중첩 라우팅으로 수정 (848dddd)
- /auth/signin : 로그인
- /auth/signup : 회원가입

### type 선언시 액션의 상위 name 추가 (f4f9fec)
- redux 개발자 도구에서 action 확인시 구분하기 편하도록  

before)
```
SET_PAGE
SET_HEADER_TITLE
GET_TODOS  
GET_TODOS_SUCCESS  
```
after)
```
layout/SET_PAGE  
layout/SET_HEADER_TITLE  
todo/GET_TODOS  
todo/GET_TODOS_SUCCESS  
```

<br/><br/>

# 기능 추가 구현

### layout reducer 생성(e77419b) 및 적용(4e1dbc6)
- 페이지 구분, header 등 공통 레이아웃과 관련된 값 저장
- Header 컴포넌트에서 props로 받아서 제목 표현하던 부분 useSelector로 변경
- 각 페이지 접근시 페이지 정보(enum값) 세팅

### 투두 상세보기용 단건 조회 saga, reducer 생성 (db7b261)
- Response Data가 없을 경우 error 처리
ex) `throw new Error('There is no response result data.')`

### 토큰 정보를 전역으로 관리하기 위해 store에 저장하는 action 생성 (30c4a3c)

### 투두 생성(Create), 수정(Update), 삭제(Delete) saga 생성 (07f0ccd)

<br/><br/>